### PR TITLE
Fix variable used for filtering repos

### DIFF
--- a/.github/workflows/notifier.yaml
+++ b/.github/workflows/notifier.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Filter out archived repos
         id: filter-repos
         run: |
-          echo '${{ steps.get-org-repos.outputs.data }}' | \
+          echo '${{ steps.get-org-repos.outputs.repos }}' | \
           jq '[.[] | select(.archived == false)] | map(.name)' > repos.json
           echo "repos=$(cat repos.json)" >> $GITHUB_OUTPUT
     outputs:


### PR DESCRIPTION
The filtering code was using steps.get-org-repos.outputs.data instead of steps.get-org-repos.outputs.repos