### PR TITLE
Remove one of the test log upload actions.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -244,12 +244,6 @@ jobs:
           label: public testing failed
           type: add
 
-      - name: Upload test results
-        if: failure()
-        uses: EnricoMi/publish-unit-test-result-action/composite@v1
-        with:
-          files: logs/**/*.xml
-
       - name: Upload logfiles
         if: failure()
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
The EnricoMi publishing action we’re calling seems to be somewhat redundant with the following action which uploads log files.

It claims to be about “unit test results” but the logs we’re passing it aren’t for what we consider our “unit tests”.

It doesn’t seem to process our log files well, resulting in a PR note about test errors rather than test failures, and links that are not helpful. It also sets a state on the PR which doesn’t get cleared if tests pass on re-running.

A detailed PR note and log file links are a great idea, but this action and our log files don’t cooperate to give us that.