### PR TITLE
Add checkout to testing jobs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -206,6 +206,10 @@ jobs:
       - name: Start Public
         run: echo "Public Testing Stage Starting"
 
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
       - name: Add public testing running
         uses: buildsville/add-remove-label@v2.0.0
         with:
@@ -316,6 +320,10 @@ jobs:
     steps:
       - name: Start Public
         run: echo "Private Testing Stage Starting"
+
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Add private testing running label
         uses: buildsville/add-remove-label@v2.0.0


### PR DESCRIPTION
Since the build and test jobs are processed separately -- in fact, they can even run on different runner systems -- there is no assurance that the test job will run against the tree produced by the build job. (There is a dependency between them, but they are separate jobs, and the built tree is not carried over from one to the other.)  We need to ensure that the correct version will be used, by checking it out.